### PR TITLE
fix: 토큰 헤더로 전달, 예외처리 및 상태코드 변경

### DIFF
--- a/insta.py
+++ b/insta.py
@@ -50,7 +50,11 @@ def get_long_token(short_access_token: str):
 
 
 def get_refresh_token(long_access_token: str):
-    return requests.get(refresh_token_url+long_access_token).json()
+    try:
+        refresh_token = requests.get(refresh_token_url+long_access_token).json()
+        return refresh_token
+    except Exception as ex:
+        return -1
 
 
 # 엑세스 토큰으로 user info 반환

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 
 from os import access
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from starlette.responses import RedirectResponse
 
 from starlette.middleware.cors import CORSMiddleware
@@ -60,13 +60,16 @@ def go_to_authorize_page():
 # A-2
 # 장기 토큰을 리프레쉬 하여 반환. 만료된 토큰이면 A-1 API로 리디렉션된다.
 # 프론트에서 발급 받은 토큰 저장 후 user_info_change_by_access_token 호출
-@app.get("/api/v1/refresh-token")
-def get_refresh_token(long_access_token: str):
+@app.get("/api/v1/refresh-token", status_code=200)
+def get_refresh_token(long_access_token: str = Header(default=None)):
     res = insta.get_refresh_token(long_access_token=long_access_token)
     # 토큰이 만료되었다면
-    if res['expires_in'] < 30:
+    if res == -1:
         go_to_authorize_page()
-    return res
+
+    elif res['expires_in'] < 30:
+        go_to_authorize_page()
+    else: return res
 
 
 # A-8
@@ -77,11 +80,11 @@ def get_refresh_token(long_access_token: str):
 def get_insta_code(code=None, error=None, error_description=None):
     # 인증 실패 시
     if error is not None:
-        raise HTTPException(status_code=404, detail=error_description)
+        raise HTTPException(status_code=421, detail=error_description)
         # 적절한 페이지로 이동시키기
     # 코드가 없으면
     if code is None:
-        raise HTTPException(status_code=404, detail="code is not found")
+        raise HTTPException(status_code=421, detail="code is not found")
     # 단기 실행 토큰 발급
     short_token = insta.get_short_token(code)
     # 장기 실행 토큰 발급

--- a/routers/users.py
+++ b/routers/users.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 
 import sys, os
@@ -18,11 +18,13 @@ router = APIRouter(
 # 또는 링크 생성 시 user 정보 업데이트를 위해 호출
 # 프론트에서는 나중에 user 정보 조회를 위해 user_id 로컬에 저장하기
 @router.put("/by-access-token")
-def user_info_change_by_access_token(access_token: str, db: Session = Depends(get_db)):
+def user_info_change_by_access_token(access_token: str = Header(default=None), db: Session = Depends(get_db)):
     # 엑세스 토큰으로 user 정보 가져옴
     user_info = insta.get_user_info(access_token=access_token)
+    if user_info is None:
+        raise HTTPException(status_code=421, detail="access_token is not valid")
 
-    # user 업데이트 시도, 성공시 user반환, 실패시 insta_id_not_found 반환
+    # user 업데이트 시도, 성공시 user반환, 실패시 -1 반환
     res = update_user(user=user_info, db=db)
 
     # user 업데이트 실패시 user 생성


### PR DESCRIPTION
토큰을 쿼리파라미터가 아닌 헤더로 전달하도록 수정
user와 인스타 관련 api 예외처리 추가
오류 상태코드 421로 변경(421: 서버로 유도된 요청은 응답을 생성할 수 없습니다. 이것은 서버에서 요청 URI와 연결된 스킴과 권한을 구성하여 응답을 생성할 수 없을 때 보내집니다.)